### PR TITLE
Initialize basic WooCommerce plugin skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# wp_plugin_booking
+# WP Plugin Booking
+
+Este repositorio contiene la estructura básica de un plugin para WordPress orientado a WooCommerce.
+
+## Estructura
+
+- `wp-plugin-booking.php` – Archivo principal del plugin.
+- `includes/` – Archivos PHP de soporte.
+- `assets/` – Recursos estáticos como JavaScript y CSS.
+- `languages/` – Archivos de traducción.
+- `templates/` – Plantillas de salida.
+- `uninstall.php` – Lógica de limpieza durante la desinstalación.
+
+## Instalación
+
+1. Copia este directorio en la carpeta `wp-content/plugins` de tu instalación de WordPress.
+2. Activa *WP Plugin Booking* desde el panel de administración de WordPress.
+
+Este es solo un punto de partida. Desde aquí puedes agregar funcionalidades específicas para reservas y personalizarlo según tus necesidades.

--- a/includes/class-wp-plugin-booking.php
+++ b/includes/class-wp-plugin-booking.php
@@ -1,0 +1,20 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WP_Plugin_Booking {
+
+    public function __construct() {
+        add_action( 'init', array( $this, 'register_custom_post_type' ) );
+    }
+
+    public function register_custom_post_type() {
+        register_post_type( 'booking', array(
+            'label' => __( 'Reserva', 'wp-plugin-booking' ),
+            'public' => true,
+            'show_in_menu' => true,
+            'supports' => array( 'title', 'editor' ),
+        ) );
+    }
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,7 @@
+<?php
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+// Limpieza de datos al desinstalar el plugin.
+

--- a/wp-plugin-booking.php
+++ b/wp-plugin-booking.php
@@ -1,0 +1,53 @@
+<?php
+/*
+Plugin Name: WP Plugin Booking
+Description: Estructura básica para un plugin de WooCommerce.
+Version: 1.0.0
+Author: Tu Nombre
+License: GPL2
+Text Domain: wp-plugin-booking
+Domain Path: /languages
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Define plugin constants.
+define( 'WP_PLUGIN_BOOKING_VERSION', '1.0.0' );
+define( 'WP_PLUGIN_BOOKING_PATH', plugin_dir_path( __FILE__ ) );
+define( 'WP_PLUGIN_BOOKING_URL', plugin_dir_url( __FILE__ ) );
+/**
+ * Activación del plugin.
+ */
+function wp_plugin_booking_activate() {
+    // Código de activación.
+}
+register_activation_hook( __FILE__, 'wp_plugin_booking_activate' );
+/**
+ * Desactivación del plugin.
+ */
+function wp_plugin_booking_deactivate() {
+    // Código de desactivación.
+}
+register_deactivation_hook( __FILE__, 'wp_plugin_booking_deactivate' );
+/**
+ * Inicializar el plugin.
+ */
+function wp_plugin_booking_init() {
+    if ( ! class_exists( 'WooCommerce' ) ) {
+        add_action( 'admin_notices', 'wp_plugin_booking_missing_wc' );
+        return;
+    }
+
+    require_once WP_PLUGIN_BOOKING_PATH . 'includes/class-wp-plugin-booking.php';
+    new WP_Plugin_Booking();
+}
+add_action( 'plugins_loaded', 'wp_plugin_booking_init' );
+/**
+ * Notificación si WooCommerce no está activo.
+ */
+function wp_plugin_booking_missing_wc() {
+    echo '<div class="error"><p>' . esc_html__( 'Se requiere WooCommerce para usar WP Plugin Booking.', 'wp-plugin-booking' ) . '</p></div>';
+}
+?>


### PR DESCRIPTION
## Summary
- create plugin entry file `wp-plugin-booking.php`
- add booking class and simple custom post type
- include uninstall script and placeholder directories
- document structure and install steps in `README`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841e4f1ca8483258da461df7a31cc12