### PR TITLE
Create booking catalog page and service CPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# wp_plugin_booking
+# WP Plugin Booking
+
+Este repositorio contiene la estructura básica de un plugin para WordPress orientado a WooCommerce. Al activarlo se crea una página llamada **Catálogo de Reservas** que usa el shortcode `[booking_catalog]` para mostrar los servicios registrados.
+
+## Estructura
+
+- `wp-plugin-booking.php` – Archivo principal del plugin.
+- `includes/` – Archivos PHP de soporte.
+- `assets/` – Recursos estáticos como JavaScript y CSS.
+- `languages/` – Archivos de traducción.
+- `templates/` – Plantillas de salida.
+- `uninstall.php` – Lógica de limpieza durante la desinstalación.
+
+## Instalación
+
+1. Copia este directorio en la carpeta `wp-content/plugins` de tu instalación de WordPress.
+2. Asegúrate de tener **WooCommerce** activo.
+3. Activa *WP Plugin Booking* desde el panel de administración de WordPress.
+
+Al activar el plugin se registrará el tipo de contenido **Servicio** con sus categorías y un campo de precio por persona. Además se creará una página para mostrar el catálogo que no usa la plantilla del tema, ofreciendo un diseño limpio y profesional.

--- a/assets/css/catalog.css
+++ b/assets/css/catalog.css
@@ -1,0 +1,27 @@
+.wpb-catalog {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    font-family: Arial, sans-serif;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 40px;
+}
+.wpb-service {
+    background: #fff;
+    border: 1px solid #ddd;
+    padding: 20px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    width: calc(33% - 20px);
+    box-sizing: border-box;
+}
+.wpb-service h2 {
+    margin-top: 0;
+    font-size: 1.5em;
+    color: #333;
+}
+.wpb-price {
+    font-weight: bold;
+    color: #0085ba;
+    margin-bottom: 10px;
+}

--- a/includes/class-wp-plugin-booking.php
+++ b/includes/class-wp-plugin-booking.php
@@ -1,0 +1,95 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WP_Plugin_Booking {
+
+    public function __construct() {
+        add_action( 'init', array( $this, 'register_service_cpt' ) );
+        add_action( 'init', array( $this, 'register_service_meta' ) );
+        add_shortcode( 'booking_catalog', array( $this, 'booking_catalog_shortcode' ) );
+        add_filter( 'template_include', array( $this, 'catalog_template' ) );
+        add_action( 'add_meta_boxes', array( $this, 'add_price_meta_box' ) );
+        add_action( 'save_post_wpb_service', array( $this, 'save_price_meta' ) );
+    }
+
+    public function register_service_cpt() {
+        register_post_type( 'wpb_service', array(
+            'label' => __( 'Servicio', 'wp-plugin-booking' ),
+            'public' => true,
+            'show_in_menu' => true,
+            'supports' => array( 'title', 'editor', 'thumbnail' ),
+            'rewrite' => array( 'slug' => 'servicio' ),
+        ) );
+
+        register_taxonomy( 'wpb_service_category', 'wpb_service', array(
+            'label' => __( 'Categorías de Servicio', 'wp-plugin-booking' ),
+            'hierarchical' => true,
+            'rewrite' => array( 'slug' => 'categoria-servicio' ),
+        ) );
+    }
+
+    public function register_service_meta() {
+        register_post_meta( 'wpb_service', '_wpb_price_per_person', array(
+            'type'              => 'number',
+            'single'            => true,
+            'show_in_rest'      => true,
+            'sanitize_callback' => 'floatval',
+            'auth_callback'     => function() { return current_user_can( 'edit_posts' ); },
+        ) );
+    }
+
+    public function add_price_meta_box() {
+        add_meta_box(
+            'wpb_service_price',
+            __( 'Precio por Persona', 'wp-plugin-booking' ),
+            array( $this, 'render_price_meta_box' ),
+            'wpb_service',
+            'side'
+        );
+    }
+
+    public function render_price_meta_box( $post ) {
+        $value = get_post_meta( $post->ID, '_wpb_price_per_person', true );
+        echo '<label for="wpb_price_per_person">' . esc_html__( 'Precio', 'wp-plugin-booking' ) . '</label>';
+        echo '<input type="number" step="0.01" name="wpb_price_per_person" id="wpb_price_per_person" value="' . esc_attr( $value ) . '" style="width:100%;" />';
+    }
+
+    public function save_price_meta( $post_id ) {
+        if ( isset( $_POST['wpb_price_per_person'] ) ) {
+            update_post_meta( $post_id, '_wpb_price_per_person', floatval( $_POST['wpb_price_per_person'] ) );
+        }
+    }
+
+    public function booking_catalog_shortcode() {
+        wp_enqueue_style( 'wpb-catalog', WP_PLUGIN_BOOKING_URL . 'assets/css/catalog.css', array(), WP_PLUGIN_BOOKING_VERSION );
+        $query = new WP_Query( array(
+            'post_type'      => 'wpb_service',
+            'posts_per_page' => -1,
+        ) );
+        ob_start();
+        echo '<div class="wpb-catalog">';
+        while ( $query->have_posts() ) {
+            $query->the_post();
+            $price = get_post_meta( get_the_ID(), '_wpb_price_per_person', true );
+            echo '<div class="wpb-service">';
+            echo '<h2>' . esc_html( get_the_title() ) . '</h2>';
+            if ( $price ) {
+                echo '<div class="wpb-price">' . esc_html( wc_price( $price ) ) . '</div>';
+            }
+            echo '<div class="wpb-content">' . apply_filters( 'the_content', get_the_content() ) . '</div>';
+            echo '</div>';
+        }
+        wp_reset_postdata();
+        echo '</div>';
+        return ob_get_clean();
+    }
+
+    public function catalog_template( $template ) {
+        if ( is_page( get_option( 'wp_booking_catalog_page_id' ) ) ) {
+            return WP_PLUGIN_BOOKING_PATH . 'templates/catalog-template.php';
+        }
+        return $template;
+    }
+}

--- a/templates/catalog-template.php
+++ b/templates/catalog-template.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Template for Booking Catalog page.
+ */
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class( 'wpb-catalog-page' ); ?>>
+<?php echo do_shortcode( '[booking_catalog]' ); ?>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,11 @@
+<?php
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+$page_id = get_option( 'wp_booking_catalog_page_id' );
+if ( $page_id ) {
+    wp_delete_post( $page_id, true );
+}
+delete_option( 'wp_booking_catalog_page_id' );
+

--- a/wp-plugin-booking.php
+++ b/wp-plugin-booking.php
@@ -1,0 +1,59 @@
+<?php
+/*
+Plugin Name: WP Plugin Booking
+Description: Sistema de reservas integrado con WooCommerce.
+Version: 1.0.0
+Author: Tu Nombre
+License: GPL2
+Text Domain: wp-plugin-booking
+Domain Path: /languages
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Define plugin constants.
+define( 'WP_PLUGIN_BOOKING_VERSION', '1.0.0' );
+define( 'WP_PLUGIN_BOOKING_PATH', plugin_dir_path( __FILE__ ) );
+define( 'WP_PLUGIN_BOOKING_URL', plugin_dir_url( __FILE__ ) );
+
+function wp_plugin_booking_activate() {
+    if ( ! class_exists( 'WooCommerce' ) ) {
+        deactivate_plugins( plugin_basename( __FILE__ ) );
+        wp_die( esc_html__( 'Se requiere WooCommerce para activar este plugin.', 'wp-plugin-booking' ) );
+    }
+    $page_id = get_option( 'wp_booking_catalog_page_id' );
+    if ( ! $page_id || ! get_post( $page_id ) ) {
+        $page_id = wp_insert_post( array(
+            'post_title'   => 'Catálogo de Reservas',
+            'post_name'    => 'booking-catalog',
+            'post_content' => '[booking_catalog]',
+            'post_status'  => 'publish',
+            'post_type'    => 'page',
+        ) );
+        update_option( 'wp_booking_catalog_page_id', $page_id );
+    }
+    flush_rewrite_rules();
+}
+register_activation_hook( __FILE__, 'wp_plugin_booking_activate' );
+
+function wp_plugin_booking_deactivate() {
+    flush_rewrite_rules();
+}
+register_deactivation_hook( __FILE__, 'wp_plugin_booking_deactivate' );
+
+function wp_plugin_booking_init() {
+    if ( ! class_exists( 'WooCommerce' ) ) {
+        add_action( 'admin_notices', 'wp_plugin_booking_missing_wc' );
+        return;
+    }
+
+    require_once WP_PLUGIN_BOOKING_PATH . 'includes/class-wp-plugin-booking.php';
+    new WP_Plugin_Booking();
+}
+add_action( 'plugins_loaded', 'wp_plugin_booking_init' );
+
+function wp_plugin_booking_missing_wc() {
+    echo '<div class="error"><p>' . esc_html__( 'Se requiere WooCommerce para usar WP Plugin Booking.', 'wp-plugin-booking' ) . '</p></div>';
+}


### PR DESCRIPTION
## Summary
- create Service post type with categories and price meta
- add activation hook to generate a catalog page with shortcode
- implement shortcode and custom template for a clean standalone catalog
- style catalog entries with basic CSS
- include empty languages folder for translations

## Testing
- `php -l wp-plugin-booking.php`
- `php -l includes/class-wp-plugin-booking.php`
- `php -l templates/catalog-template.php`
- `php -l uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_6841e4f1ca8483258da461df7a31cc12